### PR TITLE
Add extended length support

### DIFF
--- a/eventio.ksy
+++ b/eventio.ksy
@@ -1,5 +1,5 @@
 meta:
-  id: eventio
+  id: eventio_kaitai
   title: EventIO file
   license: CC0-1.0
   ks-version: 0.1
@@ -13,7 +13,7 @@ seq:
   - id: objects
     type: top_level_object
     repeat: eos
-    
+
 types:
   object:
     seq:
@@ -21,25 +21,26 @@ types:
         type: object_header
       - id: subobjects
         if: header.container == true
-        type: objects
         size: header.length
+        type: objects
+
       - id: payload
         if: header.container == false
         size: header.length
-  
+
   objects:
     seq:
       - id: objects
         type: object
         repeat: eos
-  
+
   object_header:
     seq:
       - id: type
         type: u2
       - id: user_bit
         type: b1
-      - id: extended_length
+      - id: is_extended_length
         type: b1
       - id: reserved_type
         type: b2
@@ -47,13 +48,22 @@ types:
         type: b12
       - id: id
         type: s4
-      - id: length
+      - id: base_length
         type: b30
       - id: container
         type: b1
       - id: reserved_length
         type: b1
-  
+      - id: extended_length
+        if: is_extended_length
+        type: b12
+      - id: reserved_extended
+        if: is_extended_length
+        type: b20
+    instances:
+      length:
+        value: 'is_extended_length ? (extended_length << 30) | base_length : base_length'
+
   top_level_object:
     seq:
       - id: sync_marker


### PR DESCRIPTION
Add support for extended length field.

Unfortunately, it's kind of hard to test as it is only applicable for payloads that are larger than 1 GiB.

That's also why for a long time there was a bug in the c reference *writer* implementation preventing these objects (fixed somewhen in 2018 I think).

I have one file that exceeds this and is using the extended bit, but it's 11 GiB large.